### PR TITLE
allow empty config

### DIFF
--- a/Test/Case/View/Helper/Bs3FormHelperTest.php
+++ b/Test/Case/View/Helper/Bs3FormHelperTest.php
@@ -313,6 +313,16 @@ class Bs3FormHelperTest extends CakeTestCase {
 			)
 		);
 		$this->assertEquals($result, $expected);
+
+		// Test configured options missing styles
+		Configure::write('Bs3.Form', array(
+			'formDefaults' => array(),
+			'inputDefaults' => array()
+		));
+
+		$result = $this->Form->listFormStyles();
+		$expected = array();
+		$this->assertEquals($result, $expected);
 	}
 
 /**

--- a/View/Helper/Bs3FormHelper.php
+++ b/View/Helper/Bs3FormHelper.php
@@ -818,7 +818,11 @@ class Bs3FormHelper extends FormHelper {
  * @return array
  */
 	public function listFormStyles() {
-		return array_keys(Configure::read('Bs3.Form.styles'));
+		if(Configure::check('Bs3.Form.styles')) {
+			return array_keys(Configure::read('Bs3.Form.styles'));
+		} else {
+			return array();
+		}
 	}
 
 /**


### PR DESCRIPTION
Empty config causes php warnings:

```
Warning (2): array_keys() expects parameter 1 to be array, null given [APP/Plugin/Bs3Helpers/View/Helper/Bs3FormHelper.php, line 821]
```

Which also leads to antoher warning:
```
Warning (2): Invalid argument supplied for foreach() [APP/Plugin/Bs3Helpers/View/Helper/Bs3FormHelper.php, line 915]
```